### PR TITLE
Support both js compilers

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
     }
 
     js {
+        moduleName = "${rootProject.name}-${project.name}"
         nodejs {
         }
         compilations.all {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,5 @@ infraVersion = 0.1.0-dev-51
 kotlinVersion = 1.4.0
 
 kotlin.incremental.multiplatform=true
+
+kotlin.js.compiler=both


### PR DESCRIPTION
Use `both` compilers to provide 2 variants of JS artifacts: `legacy` and `ir`