### PR TITLE
Bump Gradle version in README to 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ kotlin {
     sourceSets {
         commonMain {
              dependencies {
-                 implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3")
+                 implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.1")
              }
         }
     }


### PR DESCRIPTION
Makes it consistent with the Maven snippet.