### PR TITLE
Fix Choice's default toVariant

### DIFF
--- a/core/commonMain/src/ArgType.kt
+++ b/core/commonMain/src/ArgType.kt
@@ -74,13 +74,18 @@ abstract class ArgType<T : Any>(val hasParameter: kotlin.Boolean) {
         /**
          * Helper for arguments that have limited set of possible values represented as enumeration constants.
          */
-        inline fun <reified T: Enum<T>> Choice(
-            noinline toVariant: (kotlin.String) -> T = {
-                enumValues<T>().find { e -> e.toString().equals(it, ignoreCase = true) } ?:
-                        throw IllegalArgumentException("No enum constant $it")
-            },
-            noinline toString: (T) -> kotlin.String = { it.toString().lowercase() }): Choice<T> {
-            return Choice(enumValues<T>().toList(), toVariant, toString)
+        inline fun <reified T : Enum<T>> Choice(
+            noinline toVariant: ((kotlin.String) -> T)? = null,
+            noinline toString: (T) -> kotlin.String = { it.toString().lowercase() }
+        ): Choice<T> {
+            return Choice(
+                enumValues<T>().toList(),
+                toVariant ?: {
+                    enumValues<T>().find { e -> toString(e).equals(it, ignoreCase = true) }
+                        ?: throw IllegalArgumentException("No enum constant $it")
+                },
+                toString
+            )
         }
     }
 

--- a/core/commonTest/src/ErrorTests.kt
+++ b/core/commonTest/src/ErrorTests.kt
@@ -74,6 +74,17 @@ class ErrorTests {
         assertTrue("Option sources is expected to be one of [local, staging, production]. debug is provided." in exception.message!!)
     }
 
+    @Test
+    fun testWrongEnumChoiceWithCustomToString() {
+        val argParser = ArgParser("testParser").avoidProcessExit()
+        val sources by argParser.option(ArgType.Choice<DataSourceEnum> { it.name[0].toString().lowercase() },
+            "sources", "s", "Data sources")
+        val exception = assertFailsWith<IllegalStateException> {
+            argParser.parse(arrayOf("-s", "d"))
+        }
+        assertTrue("Option sources is expected to be one of [l, s, p]. d is provided." in exception.message!!)
+    }
+
     object KeyValue: ArgType<Pair<String, String>>(true) {
         override val description: kotlin.String
             get() {

--- a/core/commonTest/src/OptionsTests.kt
+++ b/core/commonTest/src/OptionsTests.kt
@@ -143,4 +143,17 @@ class OptionsTests {
         assertEquals(ArgParser.ValueOrigin.REDEFINED, rendersOption.valueOrigin)
         assertEquals(ArgParser.ValueOrigin.REDEFINED, sourcesOption.valueOrigin)
     }
+
+    @Test
+    fun testEnumChoiceWithCustomToString() {
+        val argParser = ArgParser("testParser")
+        val source by argParser.option(
+            ArgType.Choice<DataSourceEnum> {
+                it.name[0].toString().lowercase()
+            },
+            "sources", "s", "Data sources"
+        )
+        argParser.parse(arrayOf("-s", "S"))
+        assertEquals(DataSourceEnum.STAGING, source)
+    }
 }


### PR DESCRIPTION
Fixes #76

Some required reordering, but basically changing from `e.toString()` to `toString(e)`.